### PR TITLE
Use ~/ instead of %HOME% for Unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By default, there are six major game launchers built in; albeit without the file
 When in the app, only six launchers are shown on the header at a time, this **will** be fixed in coming updates.
 | Platform | Path |
 |--|--|
-| Windows | %APPDATA%/Roaming/argon/cache/data.json |
-| Mac (Darwin) | %HOME%/Library/Preferences/argon/cache/data.json |
-| Linux | %HOME%/argon-app/argon/cache/data.json |
+| Windows | %APPDATA%\Roaming\argon\cache\data.json |
+| Mac (Darwin) | ~/Library/Preferences/argon/cache/data.json |
+| Linux | ~/argon-app/argon/cache/data.json |
 

--- a/app/lib/data.js
+++ b/app/lib/data.js
@@ -4,8 +4,8 @@ const fs = require("fs");
 const appDataPath =
   process.env.APPDATA ||
   (process.platform === "darwin"
-    ? process.env.HOME + "/Library/Preferences"
-    : process.env.HOME + "/argon-app");
+    ? "~/Library/Preferences"
+    : "~/argon-app");
 
 const appDataDir = appDataPath + "/argon";
 const cacheDataDir = appDataPath + "/argon/cache";


### PR DESCRIPTION
~/ is probably a better way to reference the home directory on unix systems. I am not able to test this right now, so @zNotChill should review before merging. I think I got both spots where the home directory is used, but I’m not 100% sure. 